### PR TITLE
Improve error message

### DIFF
--- a/main.go
+++ b/main.go
@@ -56,7 +56,7 @@ func runScript(runner string, filePath string, workingDir string) (int, error) {
 
 	paramList = append(paramList, filePath)
 
-	script := command.NewWithStandardOuts(binary, paramList...).SetStdin(os.Stdin).SetDir(workingDir)
+	script := command.New(binary, paramList...).SetDir(workingDir)
 
 	out, err := script.RunAndReturnTrimmedCombinedOutput()
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -59,16 +59,10 @@ func runScript(runner string, filePath string, workingDir string) (int, error) {
 
 	script := command.NewWithStandardOuts(binary, paramList...).SetStdin(os.Stdin).SetDir(workingDir)
 
-	exitCode, err := script.RunAndReturnExitCode()
+	out, err := script.RunAndReturnTrimmedCombinedOutput()
 	if err != nil {
-		errorString := fmt.Sprintf("Error: %s, command: %#v", err.Error(), script.GetCmd())
-
-		if exitCode == 0 {
-			return 1, errors.New(errorString)
-		}
-
-		return exitCode, errors.New(errorString)
+		return 1, fmt.Errorf("Error: %s\n%s", err.Error(), out)
 	}
 
-	return exitCode, nil
+	return 0, nil
 }

--- a/main.go
+++ b/main.go
@@ -51,17 +51,16 @@ func runScript(runner string, filePath string, workingDir string) (int, error) {
 		binary = splitRunner[0]
 		paramList = splitRunner[1:]
 	} else {
-		return 1, fmt.Errorf("shell quote split error: %s", err.Error())
+		return 1, fmt.Errorf("shell quote split errpr: %s", err.Error())
 	}
 
 	paramList = append(paramList, filePath)
 
 	script := command.New(binary, paramList...).SetDir(workingDir)
 
-	out, err := script.RunAndReturnTrimmedCombinedOutput()
+	exitCode, err := script.RunAndReturnExitCode()
 	if err != nil {
-		exitCode := script.GetCmd().ProcessState.ExitCode()
-		return exitCode, fmt.Errorf("script run error: %s\n%s", err.Error(), out)
+		return exitCode, fmt.Errorf("script run error: %w", err)
 	}
 
 	return 0, nil

--- a/main.go
+++ b/main.go
@@ -41,14 +41,14 @@ func main() {
 		prettyError := fmt.Sprintf(
 			`Your script returned an error. Check the output above for the root cause.
 Additional details:
-Script: %s
-Working directory: %s
-Exit code: %s
-Error: %s
+Script: \t%s
+Working directory: \t%s
+Exit code: \t%s
+Error: \t%s
 `,
 			colorstring.Cyan(filePath),
-			colorstring.Red(workingDir),
-			colorstring.Cyan(fmt.Sprintf("%d", exitCode)),
+			colorstring.Cyan(workingDir),
+			colorstring.Red(fmt.Sprintf("%d", exitCode)),
 			colorstring.Red(err.Error()),
 		)
 		fmt.Println("-------------------") // Separate streamed stdout/stderr from the step's error message

--- a/main.go
+++ b/main.go
@@ -39,13 +39,14 @@ func main() {
 	exitCode, err := runScript(runner, filePath, workingDir)
 	if err != nil {
 		prettyError := fmt.Sprintf(
-			`Your script returned an error. Check the output above for the root cause.
+			`%s
 Additional details:
 Script: \t%s
 Working directory: \t%s
 Exit code: \t%s
 Error: \t%s
 `,
+			colorstring.Red("Your script returned an error. Check the output above for the root cause."),
 			colorstring.Cyan(filePath),
 			colorstring.Cyan(workingDir),
 			colorstring.Red(fmt.Sprintf("%d", exitCode)),

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"os"
 
@@ -52,7 +51,7 @@ func runScript(runner string, filePath string, workingDir string) (int, error) {
 		binary = splitRunner[0]
 		paramList = splitRunner[1:]
 	} else {
-		return 1, fmt.Errorf("Error: %s", err.Error())
+		return 1, fmt.Errorf("shell quote split errpr: %s", err.Error())
 	}
 
 	paramList = append(paramList, filePath)
@@ -61,7 +60,7 @@ func runScript(runner string, filePath string, workingDir string) (int, error) {
 
 	out, err := script.RunAndReturnTrimmedCombinedOutput()
 	if err != nil {
-		return 1, fmt.Errorf("Error: %s\n%s", err.Error(), out)
+		return 1, fmt.Errorf("script run error: %s\n%s", err.Error(), out)
 	}
 
 	return 0, nil

--- a/main.go
+++ b/main.go
@@ -60,7 +60,8 @@ func runScript(runner string, filePath string, workingDir string) (int, error) {
 
 	out, err := script.RunAndReturnTrimmedCombinedOutput()
 	if err != nil {
-		return 1, fmt.Errorf("script run error: %s\n%s", err.Error(), out)
+		exitCode := script.GetCmd().ProcessState.ExitCode()
+		return exitCode, fmt.Errorf("script run error: %s\n%s", err.Error(), out)
 	}
 
 	return 0, nil

--- a/main.go
+++ b/main.go
@@ -51,7 +51,7 @@ func runScript(runner string, filePath string, workingDir string) (int, error) {
 		binary = splitRunner[0]
 		paramList = splitRunner[1:]
 	} else {
-		return 1, fmt.Errorf("shell quote split errpr: %s", err.Error())
+		return 1, fmt.Errorf("shell quote split error: %s", err.Error())
 	}
 
 	paramList = append(paramList, filePath)

--- a/main.go
+++ b/main.go
@@ -56,7 +56,7 @@ func runScript(runner string, filePath string, workingDir string) (int, error) {
 
 	paramList = append(paramList, filePath)
 
-	script := command.New(binary, paramList...).SetDir(workingDir)
+	script := command.NewWithStandardOuts(binary, paramList...).SetDir(workingDir)
 
 	exitCode, err := script.RunAndReturnExitCode()
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/kballard/go-shellquote"
 
-	"github.com/bitrise-io/colorstring"
+	"github.com/bitrise-io/go-utils/colorstring"
 	"github.com/bitrise-io/go-utils/command"
 	"github.com/bitrise-io/go-utils/pathutil"
 	"github.com/bitrise-tools/go-steputils/input"
@@ -48,7 +48,7 @@ Error: %s
 `,
 			colorstring.Cyan(filePath),
 			colorstring.Red(workingDir),
-			colorstring.Cyan(string(exitCode)),
+			colorstring.Cyan(fmt.Sprintf("%d", exitCode)),
 			colorstring.Red(err.Error()),
 		)
 		fmt.Println("-------------------") // Separate streamed stdout/stderr from the step's error message

--- a/vendor/github.com/bitrise-io/go-utils/colorstring/colorstring.go
+++ b/vendor/github.com/bitrise-io/go-utils/colorstring/colorstring.go
@@ -1,0 +1,110 @@
+package colorstring
+
+import (
+	"fmt"
+)
+
+// Color ...
+// ANSI color escape sequences
+type Color string
+
+const (
+	blackColor   Color = "\x1b[30;1m"
+	redColor     Color = "\x1b[31;1m"
+	greenColor   Color = "\x1b[32;1m"
+	yellowColor  Color = "\x1b[33;1m"
+	blueColor    Color = "\x1b[34;1m"
+	magentaColor Color = "\x1b[35;1m"
+	cyanColor    Color = "\x1b[36;1m"
+	resetColor   Color = "\x1b[0m"
+)
+
+// ColorFunc ...
+type ColorFunc func(a ...interface{}) string
+
+func addColor(color Color, msg string) string {
+	return string(color) + msg + string(resetColor)
+}
+
+// NoColor ...
+func NoColor(a ...interface{}) string {
+	return fmt.Sprint(a...)
+}
+
+// Black ...
+func Black(a ...interface{}) string {
+	return addColor(blackColor, fmt.Sprint(a...))
+}
+
+// Red ...
+func Red(a ...interface{}) string {
+	return addColor(redColor, fmt.Sprint(a...))
+}
+
+// Green ...
+func Green(a ...interface{}) string {
+	return addColor(greenColor, fmt.Sprint(a...))
+}
+
+// Yellow ...
+func Yellow(a ...interface{}) string {
+	return addColor(yellowColor, fmt.Sprint(a...))
+}
+
+// Blue ...
+func Blue(a ...interface{}) string {
+	return addColor(blueColor, fmt.Sprint(a...))
+}
+
+// Magenta ...
+func Magenta(a ...interface{}) string {
+	return addColor(magentaColor, fmt.Sprint(a...))
+}
+
+// Cyan ...
+func Cyan(a ...interface{}) string {
+	return addColor(cyanColor, fmt.Sprint(a...))
+}
+
+// ColorfFunc ...
+type ColorfFunc func(format string, a ...interface{}) string
+
+// NoColorf ...
+func NoColorf(format string, a ...interface{}) string {
+	return NoColor(fmt.Sprintf(format, a...))
+}
+
+// Blackf ...
+func Blackf(format string, a ...interface{}) string {
+	return Black(fmt.Sprintf(format, a...))
+}
+
+// Redf ...
+func Redf(format string, a ...interface{}) string {
+	return Red(fmt.Sprintf(format, a...))
+}
+
+// Greenf ...
+func Greenf(format string, a ...interface{}) string {
+	return Green(fmt.Sprintf(format, a...))
+}
+
+// Yellowf ...
+func Yellowf(format string, a ...interface{}) string {
+	return Yellow(fmt.Sprintf(format, a...))
+}
+
+// Bluef ...
+func Bluef(format string, a ...interface{}) string {
+	return Blue(fmt.Sprintf(format, a...))
+}
+
+// Magentaf ...
+func Magentaf(format string, a ...interface{}) string {
+	return Magenta(fmt.Sprintf(format, a...))
+}
+
+// Cyanf ...
+func Cyanf(format string, a ...interface{}) string {
+	return Cyan(fmt.Sprintf(format, a...))
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,5 +1,6 @@
 # github.com/bitrise-io/go-utils v1.0.2
 ## explicit; go 1.13
+github.com/bitrise-io/go-utils/colorstring
 github.com/bitrise-io/go-utils/command
 github.com/bitrise-io/go-utils/fileutil
 github.com/bitrise-io/go-utils/pathutil


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

Before:

```
Error: exit status 1, command: &exec.Cmd{Path:"/usr/bin/bash", Args:[]string{"bash", "/bitrise/src/_scripts/generate_system_report.sh"}, Env:[]string(nil), Dir:"/bitrise/src", Stdin:(*os.File)(0xc00012e000), Stdout:(*os.File)(0xc00012e008), Stderr:(*os.File)(0xc00012e010), ExtraFiles:[]*os.File(nil), SysProcAttr:(*syscall.SysProcAttr)(nil), Process:(*os.Process)(0xc00012c2a0), ProcessState:(*os.ProcessState)(0xc000126180), ctx:context.Context(nil), lookPathErr:error(nil), finished:true, childFiles:[]*os.File{(*os.File)(0xc00012e000), (*os.File)(0xc00012e008), (*os.File)(0xc00012e010)}, closeAfterStart:[]io.Closer(nil), closeAfterWait:[]io.Closer(nil), goroutine:[]func() error(nil), errch:(chan error)(nil), waitDone:(chan struct {})(nil)}
exit status 1
```

After:
```
exit status 1
anything else from stdout + stderr
```

### Changes

<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
