### PR TITLE
Error summary

### DIFF
--- a/main.go
+++ b/main.go
@@ -39,8 +39,8 @@ func main() {
 	exitCode, err := runScript(runner, filePath, workingDir)
 	if err != nil {
 		prettyError := fmt.Sprintf(
-			`Script: \t%s
-Working directory: \t%s`,
+			`Script: %s
+Working directory: %s`,
 			colorstring.Cyan(filePath),
 			colorstring.Cyan(workingDir),
 		)

--- a/main.go
+++ b/main.go
@@ -40,11 +40,11 @@ func main() {
 	if err != nil {
 		prettyError := fmt.Sprintf(
 			`Script: \t%s
-Working directory: \t%s
-`,
+Working directory: \t%s`,
 			colorstring.Cyan(filePath),
 			colorstring.Cyan(workingDir),
 		)
+		fmt.Println("-------------------") // Separate streamed stdout/stderr from the step's error message
 		fmt.Println(prettyError)
 	}
 

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/kballard/go-shellquote"
 
+	"github.com/bitrise-io/go-utils/colorstring"
 	"github.com/bitrise-io/go-utils/command"
 	"github.com/bitrise-io/go-utils/pathutil"
 	"github.com/bitrise-tools/go-steputils/input"
@@ -35,7 +36,17 @@ func main() {
 		os.Exit(1)
 	}
 
-	exitCode, _ := runScript(runner, filePath, workingDir)
+	exitCode, err := runScript(runner, filePath, workingDir)
+	if err != nil {
+		prettyError := fmt.Sprintf(
+			`Script: \t%s
+Working directory: \t%s
+`,
+			colorstring.Cyan(filePath),
+			colorstring.Cyan(workingDir),
+		)
+		fmt.Println(prettyError)
+	}
 
 	os.Exit(exitCode)
 }

--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	exitCode, err := runScript(runner, filePath, workingDir)
+	exitCode, _ := runScript(runner, filePath, workingDir)
 
 	os.Exit(exitCode)
 }

--- a/main.go
+++ b/main.go
@@ -41,12 +41,11 @@ func main() {
 		prettyError := fmt.Sprintf(
 			`Script: \t%s
 Working directory: \t%s
-%s %s
+%s
 `,
 			colorstring.Cyan(filePath),
 			colorstring.Cyan(workingDir),
-			colorstring.Red(err.Error()),
-			colorstring.Red(fmt.Sprintf("(%d)", exitCode)),
+			colorstring.Red(fmt.Sprintf("%s (%d)", err.Error(), exitCode)),
 		)
 		fmt.Println(prettyError)
 	}

--- a/main.go
+++ b/main.go
@@ -52,7 +52,6 @@ Error: \t%s
 			colorstring.Red(fmt.Sprintf("%d", exitCode)),
 			colorstring.Red(err.Error()),
 		)
-		fmt.Println("-------------------") // Separate streamed stdout/stderr from the step's error message
 		fmt.Println(prettyError)
 	}
 

--- a/main.go
+++ b/main.go
@@ -39,18 +39,14 @@ func main() {
 	exitCode, err := runScript(runner, filePath, workingDir)
 	if err != nil {
 		prettyError := fmt.Sprintf(
-			`%s
-Additional details:
-Script: \t%s
+			`Script: \t%s
 Working directory: \t%s
-Exit code: \t%s
-Error: \t%s
+%s %s
 `,
-			colorstring.Red("Your script returned an error. Check the output above for the root cause."),
 			colorstring.Cyan(filePath),
 			colorstring.Cyan(workingDir),
-			colorstring.Red(fmt.Sprintf("%d", exitCode)),
 			colorstring.Red(err.Error()),
+			colorstring.Red(fmt.Sprintf("(%d)", exitCode)),
 		)
 		fmt.Println(prettyError)
 	}

--- a/main.go
+++ b/main.go
@@ -39,12 +39,7 @@ func main() {
 	exitCode, err := runScript(runner, filePath, workingDir)
 	if err != nil {
 		prettyError := fmt.Sprintf(
-			`Script: \t%s
-Working directory: \t%s
-%s
-`,
-			colorstring.Cyan(filePath),
-			colorstring.Cyan(workingDir),
+			`%s`,
 			colorstring.Red(fmt.Sprintf("%s (%d)", err.Error(), exitCode)),
 		)
 		fmt.Println(prettyError)

--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/kballard/go-shellquote"
 
-	"github.com/bitrise-io/go-utils/colorstring"
 	"github.com/bitrise-io/go-utils/command"
 	"github.com/bitrise-io/go-utils/pathutil"
 	"github.com/bitrise-tools/go-steputils/input"

--- a/main.go
+++ b/main.go
@@ -37,13 +37,6 @@ func main() {
 	}
 
 	exitCode, err := runScript(runner, filePath, workingDir)
-	if err != nil {
-		prettyError := fmt.Sprintf(
-			`%s`,
-			colorstring.Red(fmt.Sprintf("%s (%d)", err.Error(), exitCode)),
-		)
-		fmt.Println(prettyError)
-	}
 
 	os.Exit(exitCode)
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a PATCH [version update](https://semver.org/)

### Context

When Steps are grouped and the Step fails, the error message is missing important information about what happened.
<img width="1246" alt="Screenshot 2025-01-08 at 17 20 23" src="https://github.com/user-attachments/assets/64cf7ebc-059f-4134-9006-9a137d6380a6" />. The error message that was printed by the Script is more important by the error code.


<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->

### Changes

I removed some of the red coloured summary to enable the error message from the Script to be parsed properly. I left the path and script details.

<img width="1246" alt="Screenshot 2025-01-08 at 17 20 36" src="https://github.com/user-attachments/assets/7ed21f44-9b96-41f0-b4cf-c6fb54a0136d" />


<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

There are many ways to organise the information but the red coloured error message from the script should be the last red coloured text span.

### Decisions

I decided to remove the error code from the error summary. It can also be kept if it is not red.

<!-- Please list decisions that were made for this change. -->
